### PR TITLE
work-around for problems in IE7 and IE8

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -200,6 +200,8 @@
 							}
 						});
 					}
+					// workaround for IE7, IE8 not rendering the final rectangle in a group
+					$(canvas).append('<v:rect></v:rect>');
 				}
 			}
 


### PR DESCRIPTION
Use case is highlighting one or more sections, grouped by href, when mousing over one of them.

Worked in Chrome, Firefox, Safari and IE6, always omitted one section in IE7 and IE8.

This work-around (appending one empty VML rectangle) avoids that issue, and I regression-tested on IE6, Chrome, Firefox and Safari.
