### PR TITLE
Hack for IE9

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -5,6 +5,8 @@
 	has_VML = document.namespaces;
 	has_canvas = !!document.createElement('canvas').getContext;
 
+	has_canvas = has_canvas && !$.browser.msie;
+
 	if(!(has_canvas || has_VML)) {
 		$.fn.maphilight = function() { return this; };
 		return;


### PR DESCRIPTION
If &lt;canvas&gt; can be made and jQuery says it's IE. It's gonna be IE9.
IE9 messes up some sites where I use the plugin, but this fixed it.

There is probably a more elegant and permanent solution to the problem. This one can be used temporary. Haven't had much time to look it over for a clean solution. :)
