### PR TITLE
added support for shadows (canvas + rectangles only)

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -45,6 +45,30 @@
 				context.lineWidth = options.strokeWidth;
 				context.stroke();
 			}
+			if(options.shadow && shape == 'rect') {
+				context.save();  // store canvas state
+
+				// define clipping region
+				context.beginPath();
+				context.rect(0, 0, canvas.width, canvas.height);
+				context.rect(coords[0], coords[1]+(coords[3] - coords[1]), coords[2] - coords[0], -(coords[3] - coords[1]));
+				context.closePath();
+				context.clip()
+				
+				// draw shadow
+				context.fillStyle = 'rgb(255,255,255)';
+				context.beginPath();
+				context.rect(coords[0], coords[1]+(coords[3] - coords[1]), coords[2] - coords[0], -(coords[3] - coords[1]));
+				context.closePath();
+				context.shadowOffsetX = options.shadowX;
+				context.shadowOffsetY = options.shadowY;
+				context.shadowBlur = options.shadowRadius;
+				context.shadowColor = css3color(options.shadowColor, options.shadowOpacity);
+				context.fill();
+				context.stroke();
+				
+				context.restore(); // restore canvas state
+			}
 			if(options.fade) {
 				$(canvas).css('opacity', 0).animate({opacity: 1}, 100);
 			}


### PR DESCRIPTION
Hi! 
I recently used the maphilight jQuery plugin in a project of mine and I really wanted to have a drop shadow for the highlights, so I went ahead an wrote something that fitted my needs (target userbase is using firefox and won't have mapareas other than rectangles).
I hereby release my changes into the public and hope they may be helpful for other people, and maybe get improved to support other shapes and vml as well.
