### PR TITLE
Bugfix for maphilight on initial hidden Images

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -298,10 +298,10 @@
 					area_options = options_from_area(this, options);
 					if(area_options.alwaysOn) {
 						if(!canvas_always && has_canvas) {
-							canvas_always = create_canvas_for(img.get(0));
+							canvas_always = create_canvas_for(img[0]);
 							$(canvas_always).css(canvas_style);
-							canvas_always.width = img.width();
-							canvas_always.height = img.height();
+							canvas_always.width = img[0].width
+							canvas_always.height = img[0].height
 							img.before(canvas_always);
 						}
 						area_options.fade = area_options.alwaysOnFade; // alwaysOn shouldn't fade in initially


### PR DESCRIPTION
With these changes maphilight will work for initial hidden images, the alwaysOn canvas had a wrong size because the wrong parameter was passed to the the create_canvas_for function and the width() did return 0 for hidden Elements.
