### PR TITLE
allows area_options.groupBy to accept arrays for multiple groupings

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -277,23 +277,28 @@
 					shape = shape_from_area(this);
 					add_shape_to(canvas, shape[0], shape[1], area_options, "highlighted");
 					if(area_options.groupBy) {
-						var areas;
-						// two ways groupBy might work; attribute and selector
-						if(/^[a-zA-Z][\-a-zA-Z]+$/.test(area_options.groupBy)) {
-							areas = map.find('area['+area_options.groupBy+'="'+$(this).attr(area_options.groupBy)+'"]');
-						} else {
-							areas = map.find(area_options.groupBy);
-						}
-						var first = this;
-						areas.each(function() {
-							if(this != first) {
-								var subarea_options = options_from_area(this, options);
-								if(!subarea_options.neverOn && !subarea_options.alwaysOn) {
-									var shape = shape_from_area(this);
-									add_shape_to(canvas, shape[0], shape[1], subarea_options, "highlighted");
+						// accept either a string or an array so that multiple attributes can be used
+						(typeof area_options.groupBy == 'string') && (area_options.groupBy = [area_options.groupBy]);
+						var el = $(this); // avoid scoping problem
+							$.each(area_options.groupBy, function(index,groupitem){
+								var areas;
+								// two ways groupBy might work; attribute and selector
+								if(/^[a-zA-Z][\-a-zA-Z]+$/.test(groupitem)) {
+									areas = map.find('area['+groupitem+'="'+el.attr(groupitem)+'"]');
+								} else {
+									areas = map.find(groupitem);
 								}
-							}
-						});
+								var first = this;
+								areas.each(function() {
+									if(this != first) {
+										var subarea_options = options_from_area(this, options);
+										if(!subarea_options.neverOn && !subarea_options.alwaysOn) {
+											var shape = shape_from_area(this);
+											add_shape_to(canvas, shape[0], shape[1], subarea_options, "highlighted");
+										}
+									}
+								});
+							});
 					}
 					// workaround for IE7, IE8 not rendering the final rectangle in a group
 					if(!has_canvas) {


### PR DESCRIPTION
A map has multiple groups which are defined by separate attributes and each needs its own group case. area_options.groupBy now converts itself to an array if it isn't one already and then uses $.each() to iterate over the attributes to group by when moused over.

For example, some areas are classed by the CLASS attribute while for accessibility reasons others are classed by ARIA-LABELLEDBY and this change prevents the developer from having to create a redundant CLASS attribute. Less markup is better markup.
