### PR TITLE
Explicit background-image sizing to match possibly scaled image, allow multiple attributes for groupBy

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -245,6 +245,7 @@
 			wrap = $('<div></div>').css({
 				display:'block',
 				background:'url("'+this.src+'")',
+				"background-size":'contain',
 				position:'relative',
 				padding:0,
 				width:this.width,

--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -278,23 +278,27 @@
 					shape = shape_from_area(this);
 					add_shape_to(canvas, shape[0], shape[1], area_options, "highlighted");
 					if(area_options.groupBy) {
-						var areas;
-						// two ways groupBy might work; attribute and selector
-						if(/^[a-zA-Z][\-a-zA-Z]+$/.test(area_options.groupBy)) {
-							areas = map.find('area['+area_options.groupBy+'="'+$(this).attr(area_options.groupBy)+'"]');
-						} else {
-							areas = map.find(area_options.groupBy);
-						}
-						var first = this;
-						areas.each(function() {
-							if(this != first) {
-								var subarea_options = options_from_area(this, options);
-								if(!subarea_options.neverOn && !subarea_options.alwaysOn) {
-									var shape = shape_from_area(this);
-									add_shape_to(canvas, shape[0], shape[1], subarea_options, "highlighted");
+						(typeof area_options.groupBy == 'string') && (area_options.groupBy = [area_options.groupBy]);
+						var el = $(this);
+							$.each(area_options.groupBy, function(index,groupitem){
+								var areas;
+								// two ways groupBy might work; attribute and selector
+								if(/^[a-zA-Z][\-a-zA-Z]+$/.test(groupitem)) {
+									areas = map.find('area['+groupitem+'="'+el.attr(groupitem)+'"]');
+								} else {
+									areas = map.find(groupitem);
 								}
-							}
-						});
+								var first = this;
+								areas.each(function() {
+									if(this != first) {
+										var subarea_options = options_from_area(this, options);
+										if(!subarea_options.neverOn && !subarea_options.alwaysOn) {
+											var shape = shape_from_area(this);
+											add_shape_to(canvas, shape[0], shape[1], subarea_options, "highlighted");
+										}
+									}
+								});
+							});
 					}
 					// workaround for IE7, IE8 not rendering the final rectangle in a group
 					if(!has_canvas) {


### PR DESCRIPTION
In cases where the image has been rescaled, the wrap div shows the image at its original resolution rather than the intended one; adding this CSS ensures the wrap's background image is sized to the div's container (which matches the original image it's replacing).

Also allow groupBy to take either a single argument (as in original code) or an array, so multiple attributes can be used for groupBy.
