### PR TITLE
Add bower.json, to enable bower install maphilight

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "maphilight",
+  "version": "1.2.2",
+  "main": "jquery.maphilight.js",
+  "ignore": [
+    "**/.*",
+    "docs",
+    "tools",
+    "package.json"
+  ],
+  "dependencies": {
+    "jquery": "~1.7.2"
+  },
+  "devDependencies": {
+  }
+}


### PR DESCRIPTION
After merge, run:

```
bower register maphilight git@github.com:kemayo/maphilight.git
```

---

I believe the `1.3` tag need to be changed to `1.3.0` before it can work with bower, so I specified `1.2.2` until then.
https://github.com/bower/bower#registering-packages
