### PR TITLE
adding an explicit background size for the wrapper div

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -245,6 +245,7 @@
 			wrap = $('<div></div>').css({
 				display:'block',
 				background:'url("'+this.src+'")',
+				backgroundSize: this.width + 'px ' + this.height + 'px',
 				position:'relative',
 				padding:0,
 				width:this.width,


### PR DESCRIPTION
This will allow the map hilights to scale appropriately.  This is especially helpful if you want to use a hidpi version of your map (pixel doubled)

I know that a similar approach was included in this open pull request: https://github.com/kemayo/maphilight/pull/36

However, I think this one is more generally compatible and _only_ contains the background sizing modification.
